### PR TITLE
Setup development environment for customer account service

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Close #1 

### Details
Config the `nosetests` to show color and run coverage automatically.